### PR TITLE
Correct import syntax documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Include the monitor while setting up the DevTools:
 ```js
 import React from 'react';
 import { createDevTools } from 'redux-devtools';
-import { ImportExportMonitor } from 'redux-import-export-monitor';
+import ImportExportMonitor from 'redux-import-export-monitor';
 
 export default createDevTools(<ImportExportMonitor />);
 ```

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Include the monitor while setting up the DevTools:
 ```js
 import React from 'react';
 import { createDevTools } from 'redux-devtools';
-import ImportExportMonitor from 'redux-import-export-monitor';
+import { ImportExportMonitor } from 'redux-import-export-monitor';
 
 export default createDevTools(<ImportExportMonitor />);
 ```
@@ -37,4 +37,4 @@ Name                  | Description
 
 ### License
 
-MIT 
+MIT

--- a/src/index.js
+++ b/src/index.js
@@ -1,1 +1,2 @@
-export { default as ImportExportMonitor } from './ImportExportMonitor';
+import ImportExportMonitor from './ImportExportMonitor';
+export default ImportExportMonitor;


### PR DESCRIPTION
`ImportExportMonitor` is not exported as the default export, so importing per the current documentation actually leads to an `undefined` variable. This PR updates the Readme to reflect the correct way to import `ImportExportMonitor`.

Alternatively,`index.js` could be updated to:

```
import ImportExportMonitor from './ImportExportMonitor';
export default ImportExportMonitor;
```

Which would make `import ImportExportMonitor from 'redux-import-export-monitor';` work as expected.
