### PR TITLE
adding default contentLabel prop to Modal declaration

### DIFF
--- a/src/InputModal.js
+++ b/src/InputModal.js
@@ -24,11 +24,16 @@ const formStyle = {
 };
 
 export default class InputModal extends Component {
+  static defaultProps = {
+    contentLabel: 'Modal'
+  };
+
   static propTypes = {
     closeModal: PropTypes.func.isRequired,
     onSubmit: PropTypes.func.isRequired,
     isOpen: PropTypes.bool,
-    appState: PropTypes.string
+    appState: PropTypes.string,
+    contentLabel: PropTypes.string
   };
 
   constructor(props) {
@@ -83,7 +88,7 @@ export default class InputModal extends Component {
 
   render() {
     return (
-      <Modal style={style} isOpen={this.props.isOpen} onRequestClose={this.onRequestClose}>
+      <Modal style={style} isOpen={this.props.isOpen} onRequestClose={this.onRequestClose} contentLabel={this.props.contentLabel}>
         <div style={formStyle}>
           <input ref={(ref) => this.modalInput = ref}
             style={{ flex: 10 }}


### PR DESCRIPTION
ReactModal has updated such that it requires a contentLabel as specified in this commit
https://github.com/reactjs/react-modal/commit/3d8e5a0

By adding a `contentLabel` to the `Modal` declaration, console warnings like:
```
Warning: Failed prop type: The prop `contentLabel` is marked as required in `Modal`, but its value is `undefined`.
    in Modal (created by InputModal)
    in InputModal (created by ImportExportMonitor)
    in ImportExportMonitor
    in div (created by MultipleMonitors)
    in MultipleMonitors
    in div (created by Dock)
    in div (created by Dock)
    in div (created by Dock)
    in Dock (created by DockMonitor)
    in DockMonitor (created by Connect(DockMonitor))
    in Connect(DockMonitor) (created by DevTools)
    in DevTools (created by Root)
    in div (created by Root)
    in Provider (created by Root)
    in Root
    in AppContainer
```

will be resolved.