### PR TITLE
Import PropTypes from prop-types package

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
   },
   "dependencies": {
     "parse-key": "^0.2.1",
+    "prop-types": "^15.5.10",
     "react-addons-shallow-compare": "^0.14.0 || ^15.0.0",
     "react-modal": "^1.1.2"
   },

--- a/src/ImportExportMonitor.js
+++ b/src/ImportExportMonitor.js
@@ -1,4 +1,5 @@
-import React, { PropTypes, Component } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import shallowCompare from 'react-addons-shallow-compare';
 import { ActionCreators } from 'redux-devtools';
 import parseKey from 'parse-key';

--- a/src/InputModal.js
+++ b/src/InputModal.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import shallowCompare from 'react-addons-shallow-compare';
 import Modal from 'react-modal';
 


### PR DESCRIPTION
Resolves a deprecation warning due to `PropTypes` being removed from the main `react` package in the next upcoming major release.

https://facebook.github.io/react/blog/2017/04/07/react-v15.5.0.html#migrating-from-react.proptypes